### PR TITLE
Do not merge yet - Fix the call to `char::encode_utf8`

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -20,9 +20,8 @@ impl<W: Write> WriteExt for W {
     }
 
     fn write_char(&mut self, c: char) -> io::Result<usize> {
-        let mut buf = [0; 4];
-        let n = c.encode_utf8(&mut buf).expect("Invalid UTF-8! This is a bug: Report it to the provider of this piece of software.");
-        self.write(&buf[..n])
+        let utf8 = c.encode_utf8();
+        self.write(utf8.as_slice())
     }
 }
 


### PR DESCRIPTION
On Rust's current master the `char::encode_utf8` has changed from

``` rust
fn encode_utf8(self, dst: &mut [u8]) -> Option<usize>
```

to

``` rust
fn encode_utf8(self) -> EncodeUtf8
```

So when we will update the Rust version used by Redox this lib will break.
I am making this PR so that when we update Rust we can also update this library to use the new `encode_utf8` function.
