### PR TITLE
implement fail_because

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,45 @@ pub mod hash;
 pub mod io;
 /// Non-cryptographic pseudo-random number generators.
 pub mod rand;
+
+/// Macro for failing for a specified cause.
+///
+/// `fail_because` is a solution to this segment of code being used
+/// many many many times:
+///
+/// ```
+/// let var = function_returning_result().unwrap_or_else(|err| {
+///     eprintln!("program_name: {}", err);
+///     exit(1);
+/// });
+/// ```
+///
+/// `fail_because` provides a convenient way to fail your program for any
+/// reason that implements `Display`. It prints the name of the executable
+/// that was invoked, the error, and then exits with the specified return
+/// code (if specified).
+///
+/// # Examples
+/// Here is the above scenario with `fail_because`
+///
+/// ```
+/// let var = function_returning_result().unwrap_or_else(|err| fail_because!(err) );
+/// ```
+///
+/// `fail_because` can also take an exit code:
+///
+/// ```
+/// fail_because!(err, 8);
+/// ```
+#[macro_export]
+macro_rules! fail_because {
+    ($err:expr) => ({
+        fail_because!($err, 1);
+    });
+    ($err:expr, $exit_code:expr) => ({
+        let arg = std::env::args().next().unwrap();
+        let invoc = std::path::Path::new(&arg).file_name().unwrap().to_string_lossy();
+        eprintln!("{}: {}", invoc, $err);
+        std::process::exit($exit_code);
+    })
+}


### PR DESCRIPTION
Macro for failing for a reason, as well as printing the program name.

Don't merge this.